### PR TITLE
add support for supervisor handoff, ensure mnesia start

### DIFF
--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -1647,11 +1647,11 @@ defmodule Swarm.Tracker do
        when attempts <= @retry_max_attempts do
     case :rpc.call(node, :application, :which_applications, []) do
       app_list when is_list(app_list) ->
-        apps_to_be_started = [ :swarm | Application.get_env(:swarm, :dependent_apps, false)]
+        apps_to_be_started = [ :swarm | Application.get_env(:swarm, :dependent_apps, [])]
         all_apps_started = apps_to_be_started |> Enum.reduce(true, fn app_name, all_apps_started ->
           all_apps_started && !is_nil(List.keyfind(app_list, app_name, 0))
         end)
-        
+
         if all_apps_started do
           info("nodeup #{node}")
 

--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -897,6 +897,10 @@ defmodule Swarm.Tracker do
                           {:keep_state, new_state} -> new_state
                         end
                     end
+                  true ->
+                    # Cant handoff as neither a genserver not a supervisor
+                    debug("#{inspect(name)} - ignoring handoff due to unknown behaviour")
+                    state
                 end
               catch
                 _, err ->

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule Swarm.Mixfile do
       {:dialyxir, "~> 0.3", only: :dev},
       {:benchee, "~> 0.4", only: :dev},
       {:porcelain, "~> 2.0", only: [:dev, :test]},
-      {:libring, "~> 1.0"},
+      {:libring, "~> 1.5"},
       {:gen_state_machine, "~> 2.0"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -5,7 +5,7 @@
   "earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "gen_state_machine": {:hex, :gen_state_machine, "2.0.3", "477ea51b466a749ab23a0d6090e9e84073f41f9aa28c7efc40eac18f3d4a9f77", [:mix], [], "hexpm"},
-  "libring": {:hex, :libring, "1.4.0", "41246ba2f3fbc76b3971f6bce83119dfec1eee17e977a48d8a9cfaaf58c2a8d6", [:mix], [], "hexpm"},
+  "libring": {:hex, :libring, "1.5.0", "44313eb6862f5c9168594a061e9d5f556a9819da7c6444706a9e2da533396d70", [:mix], [], "hexpm"},
   "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [:mix], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.8.0", "1204a2f5b4f181775a0e456154830524cf2207cf4f9112215c05e0b76e4eca8b", [:mix], [{:makeup, "~> 0.5.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.2.2", "d526b23bdceb04c7ad15b33c57c4526bf5f50aaa70c7c141b4b4624555c68259", [:mix], [], "hexpm"},


### PR DESCRIPTION
Changelog
1. So, Swarm has known issues with using Supervisors. Instead of baking supervision inside swarm, We decided to let swarm run/handoff supervisors without changing anything in swarm process registry. The supervisor is responsible for running dependent child processes locally on the node where the supervisor is running. 

2. Add a swarm config called "dependent_apps". Now we also ensure that the following apps were started on remote node before registering processes on that node. One common use case it solves for is Mnesia.

